### PR TITLE
feat(search-results): adding error and no results states

### DIFF
--- a/app/src/main/java/com/sonder/codechallenge/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/com/sonder/codechallenge/ui/MainActivityViewModel.kt
@@ -3,7 +3,9 @@ package com.sonder.codechallenge.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sonder.codechallenge.ui.models.SearchActivityStates
+import com.sonder.domain.models.SearchState
 import com.sonder.domain.usecases.search.ClearSearchResultsUseCase
+import com.sonder.domain.usecases.search.SubscribeToSearchStateUseCase
 import com.sonder.domain.usecases.search.UpdateSearchQueryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
     private val updateSearchQueryUseCase: UpdateSearchQueryUseCase,
-    private val clearSearchResultsUseCase: ClearSearchResultsUseCase
+    private val clearSearchResultsUseCase: ClearSearchResultsUseCase,
+    private val subscribeToSearchStateUseCase: SubscribeToSearchStateUseCase,
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<SearchActivityStates> = MutableStateFlow(
@@ -36,6 +39,27 @@ class MainActivityViewModel @Inject constructor(
     private fun clearSearchResults() {
         viewModelScope.launch {
             clearSearchResultsUseCase.execute(Unit)
+        }
+    }
+
+    init {
+        subscribeToSearchState()
+    }
+
+    private fun subscribeToSearchState() {
+        viewModelScope.launch {
+            subscribeToSearchStateUseCase.execute(Unit)
+                .collect { state ->
+                    if (_state.value is SearchActivityStates.Searching) {
+                        when (state) {
+                            SearchState.Idle -> {
+                                val query = (_state.value as SearchActivityStates.Searching).query
+                                _state.value = SearchActivityStates.Results(query)
+                            }
+                            SearchState.Searching -> return@collect
+                        }
+                    }
+                }
         }
     }
 }

--- a/app/src/main/java/com/sonder/codechallenge/ui/MainFragment.kt
+++ b/app/src/main/java/com/sonder/codechallenge/ui/MainFragment.kt
@@ -57,6 +57,10 @@ class MainFragment : Fragment() {
                     is SearchFragmentStates.Error -> {
                         // Show error state
                     }
+
+                    SearchFragmentStates.NoResults -> {
+                        // Show no results state
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/sonder/codechallenge/ui/MainFragmentViewModel.kt
+++ b/app/src/main/java/com/sonder/codechallenge/ui/MainFragmentViewModel.kt
@@ -7,17 +7,23 @@ import com.sonder.codechallenge.ui.models.SearchFragmentStates
 import com.sonder.domain.models.SearchItemRequest
 import com.sonder.domain.models.SearchItemViewType
 import com.sonder.domain.models.SearchSectionResult
+import com.sonder.domain.models.SearchState
+import com.sonder.domain.usecases.request.GetErrorSearchResultsUseCase
 import com.sonder.domain.usecases.request.GetHorizontalCompactSearchResultsUseCase
 import com.sonder.domain.usecases.request.GetHorizontalDetailedSearchResultsUseCase
 import com.sonder.domain.usecases.request.GetVerticalCompactSearchResultsUseCase
 import com.sonder.domain.usecases.request.GetVerticalDetailedSearchResultsUseCase
 import com.sonder.domain.usecases.search.SubscribeToSearchQueryUseCase
+import com.sonder.domain.usecases.search.UpdateSearchStateUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -29,7 +35,9 @@ class MainFragmentViewModel @Inject constructor(
     private val getVerticalCompactSearchResultsUseCase: GetVerticalCompactSearchResultsUseCase,
     private val getHorizontalDetailedSearchResultsUseCase: GetHorizontalDetailedSearchResultsUseCase,
     private val getVerticalDetailedSearchResultsUseCase: GetVerticalDetailedSearchResultsUseCase,
-    private val subscribeToSearchQueryUseCase: SubscribeToSearchQueryUseCase
+    private val getErrorSearchResultsUseCase: GetErrorSearchResultsUseCase,
+    private val subscribeToSearchQueryUseCase: SubscribeToSearchQueryUseCase,
+    private val updateSearchStateUseCase: UpdateSearchStateUseCase,
 ) : ViewModel() {
 
     private var query: String? = null
@@ -48,24 +56,42 @@ class MainFragmentViewModel @Inject constructor(
                 if (it.isNotEmpty()) {
                     query = it
 
+                    updateSearchStateUseCase.execute(SearchState.Searching)
+                    delay(2000)
+
                     when(query){
                         "mock" -> fetchSearchResults()
-                        // TODO: "error" -> call use case and update state with error
-                        // TODO: else -> update state to no results
+                        "error" -> fetchErrorResults()
+                        else -> setSearchNoResults()
                     }
-
+                    updateSearchStateUseCase.execute(SearchState.Idle)
                 }
             }
         }
     }
 
+    private fun setSearchNoResults() {
+        viewModelScope.launch {
+            _state.value = SearchFragmentStates.NoResults
+        }
+    }
+
     private fun fetchSearchResults() {
         viewModelScope.launch {
-            delay(2000)
             fetchSearchResultsByType(SearchItemViewType.HORIZONTAL_COMPACT)
             fetchSearchResultsByType(SearchItemViewType.VERTICAL_COMPACT)
             fetchSearchResultsByType(SearchItemViewType.HORIZONTAL_DETAILED)
             fetchSearchResultsByType(SearchItemViewType.VERTICAL_DETAILED)
+        }
+    }
+
+    private fun fetchErrorResults() {
+        viewModelScope.launch {
+            getErrorSearchResultsUseCase.execute(Unit)
+                .catch { exception ->
+                _state.value = SearchFragmentStates.Error(message = exception.message ?: "Unknown error occurred")
+            }.collect()
+            //updateSearchStateUseCase.execute(SearchState.Idle)
         }
     }
 

--- a/app/src/main/java/com/sonder/codechallenge/ui/MainScreen.kt
+++ b/app/src/main/java/com/sonder/codechallenge/ui/MainScreen.kt
@@ -1,7 +1,10 @@
 package com.sonder.codechallenge.ui
 
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -13,10 +16,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.sonder.codechallenge.R
 import com.sonder.codechallenge.ui.components.ItemHorizontalCompact
 import com.sonder.codechallenge.ui.components.ItemHorizontalDetailed
 import com.sonder.codechallenge.ui.components.ItemVerticalCompact
@@ -56,9 +62,28 @@ fun MainScreen(state: State<SearchFragmentStates>) {
             }
 
             is SearchFragmentStates.Error -> {
-                Text("Error: ${currentState.message}")
+                DisplayMessageSection(
+                    stringResource(
+                        R.string.an_error_has_ocurred_text,
+                        currentState.message
+                    ))
+            }
+
+            SearchFragmentStates.NoResults -> {
+                DisplayMessageSection(stringResource(R.string.no_results_text))
             }
         }
+    }
+}
+
+@Composable
+fun DisplayMessageSection(message: String){
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(message)
     }
 }
 

--- a/app/src/main/java/com/sonder/codechallenge/ui/models/SearchFragmentStates.kt
+++ b/app/src/main/java/com/sonder/codechallenge/ui/models/SearchFragmentStates.kt
@@ -4,7 +4,8 @@ import com.sonder.domain.models.SearchItemRequest
 import com.sonder.domain.models.SearchSectionResult
 
 sealed class SearchFragmentStates {
-    object Started : SearchFragmentStates()
+    data object Started : SearchFragmentStates()
     data class ResultsLoaded(val sections: List<SearchItemRequest>) : SearchFragmentStates()
     data class Error(val message: String) : SearchFragmentStates()
+    data object NoResults : SearchFragmentStates()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="searching_for_text">Searching for \'%1$s\'</string>
     <string name="showing_results_for_text">Showing results for \'%1$s\'</string>
     <string name="addiction_and_dependency">Addiction and dependency</string>
+    <string name="an_error_has_ocurred_text">An error has ocurred: %1$s</string>
+    <string name="no_results_text">No results were found for your search</string>
 </resources>

--- a/data/src/main/java/com/sonder/data/SearchResultRepositoryImpl.kt
+++ b/data/src/main/java/com/sonder/data/SearchResultRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.sonder.data
+
+import com.sonder.domain.models.SearchState
+import com.sonder.domain.repositories.SearchResultRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+class SearchResultRepositoryImpl @Inject constructor() : SearchResultRepository {
+    private val _searchState: MutableStateFlow<SearchState> = MutableStateFlow(SearchState.Idle)
+    override val searchState : Flow<SearchState>
+        get() = _searchState
+
+    override fun updateSearchState(state: SearchState) {
+        _searchState.value = state
+    }
+}

--- a/data/src/main/java/com/sonder/di/DataModule.kt
+++ b/data/src/main/java/com/sonder/di/DataModule.kt
@@ -3,9 +3,11 @@ package com.sonder.di
 import com.sonder.data.MockRequestsRepositoryImpl
 import com.sonder.data.MockResponsesRepositoryImpl
 import com.sonder.data.SearchRepositoryImpl
+import com.sonder.data.SearchResultRepositoryImpl
 import com.sonder.domain.repositories.MockRequestsRepository
 import com.sonder.domain.repositories.MockResponsesRepository
 import com.sonder.domain.repositories.SearchRepository
+import com.sonder.domain.repositories.SearchResultRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,6 +22,12 @@ object DataModule {
     @Singleton
     fun provideSearchRepository(): SearchRepository {
         return SearchRepositoryImpl()
+    }
+
+    @Provides
+    @Singleton
+    fun provideSearchResultRepository(): SearchResultRepository {
+        return SearchResultRepositoryImpl()
     }
 
     @Provides

--- a/domain/src/main/java/com/sonder/domain/models/SearchState.kt
+++ b/domain/src/main/java/com/sonder/domain/models/SearchState.kt
@@ -1,0 +1,7 @@
+package com.sonder.domain.models
+
+sealed class SearchState {
+    data object Searching : SearchState()
+    data object Idle : SearchState()
+
+}

--- a/domain/src/main/java/com/sonder/domain/repositories/SearchRepository.kt
+++ b/domain/src/main/java/com/sonder/domain/repositories/SearchRepository.kt
@@ -2,7 +2,6 @@ package com.sonder.domain.repositories
 
 import kotlinx.coroutines.flow.Flow
 
-// TODO Implement SearchRepository. Change as needed.
 interface SearchRepository {
     val searchQuery: Flow<String>
     fun updateSearchQuery(query: String)

--- a/domain/src/main/java/com/sonder/domain/repositories/SearchResultRepository.kt
+++ b/domain/src/main/java/com/sonder/domain/repositories/SearchResultRepository.kt
@@ -1,0 +1,9 @@
+package com.sonder.domain.repositories
+
+import com.sonder.domain.models.SearchState
+import kotlinx.coroutines.flow.Flow
+
+interface SearchResultRepository {
+    val searchState : Flow<SearchState>
+    fun updateSearchState(state: SearchState)
+}

--- a/domain/src/main/java/com/sonder/domain/usecases/request/GetErrorSearchResultsUseCase.kt
+++ b/domain/src/main/java/com/sonder/domain/usecases/request/GetErrorSearchResultsUseCase.kt
@@ -1,0 +1,28 @@
+package com.sonder.domain.usecases.request
+
+import android.util.Log
+import com.sonder.domain.models.SearchSectionResult
+import com.sonder.domain.repositories.MockRequestsRepository
+import com.sonder.domain.repositories.MockResponsesRepository
+import com.sonder.domain.usecases.base.FlowUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetErrorSearchResultsUseCase @Inject constructor(
+    private val mockRequestsRepository: MockRequestsRepository,
+    private val mockResponsesRepository: MockResponsesRepository,
+) : FlowUseCase<Unit, SearchSectionResult>() {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun construct(params: Unit): Flow<SearchSectionResult> {
+        return mockRequestsRepository.getErrorRequestParams()
+            .flatMapLatest { _ ->
+                mockResponsesRepository.getErrorResult().map { result ->
+                    throw result
+                }
+            }
+    }
+}

--- a/domain/src/main/java/com/sonder/domain/usecases/search/SubscribeToSearchStateUseCase.kt
+++ b/domain/src/main/java/com/sonder/domain/usecases/search/SubscribeToSearchStateUseCase.kt
@@ -1,0 +1,17 @@
+package com.sonder.domain.usecases.search
+
+import com.sonder.domain.models.SearchState
+import com.sonder.domain.repositories.SearchRepository
+import com.sonder.domain.repositories.SearchResultRepository
+import com.sonder.domain.usecases.base.FlowUseCase
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SubscribeToSearchStateUseCase @Inject constructor(
+    private val searchResultRepository: SearchResultRepository,
+) : FlowUseCase<Unit, SearchState>() {
+
+    override fun construct(params: Unit): Flow<SearchState> {
+        return searchResultRepository.searchState
+    }
+}

--- a/domain/src/main/java/com/sonder/domain/usecases/search/UpdateSearchStateUseCase.kt
+++ b/domain/src/main/java/com/sonder/domain/usecases/search/UpdateSearchStateUseCase.kt
@@ -1,0 +1,16 @@
+package com.sonder.domain.usecases.search
+
+import com.sonder.domain.models.SearchState
+import com.sonder.domain.repositories.SearchRepository
+import com.sonder.domain.repositories.SearchResultRepository
+import com.sonder.domain.usecases.base.NoResultUseCase
+import javax.inject.Inject
+
+class UpdateSearchStateUseCase @Inject constructor(
+    private val searchResultRepository: SearchResultRepository,
+) : NoResultUseCase<SearchState>() {
+
+    override suspend fun construct(params: SearchState) {
+        searchResultRepository.updateSearchState(params)
+    }
+}


### PR DESCRIPTION
This MR adds states for error and no results searches.

- Added repository to store current state on search.
- Added use cases to update and subscribe to SearchState repository.
- Updates to MainActivity, MainFragment and ViewModels for both.